### PR TITLE
Single tree

### DIFF
--- a/src/main/java/pathMinder/Apple.java
+++ b/src/main/java/pathMinder/Apple.java
@@ -1,5 +1,5 @@
 package pathMinder;
 
 public class Apple extends Item {
-	public Apple() {super("Apple", (float)0.5, (float)0.03);}
+	public Apple() {super("Apple", 0.5f, 3);}
 }

--- a/src/main/java/pathMinder/Backpack.java
+++ b/src/main/java/pathMinder/Backpack.java
@@ -1,7 +1,5 @@
 package pathMinder;
 
 public class Backpack extends Container{
-	public Backpack() {
-		super(null, "Backpack, common", 2, 60, 2);
-	}
+	public Backpack() { super(null, "Backpack, common", 2.0f, 60.0f, 200); }
 }

--- a/src/main/java/pathMinder/Barrel.java
+++ b/src/main/java/pathMinder/Barrel.java
@@ -1,5 +1,5 @@
 package pathMinder;
 
 public class Barrel extends Container {
-	public Barrel() { super(null,"Barrel, wooden", 30, 650, 2); }
+	public Barrel() { super(null,"Barrel, wooden", 30.0f, 650.0f, 200); }
 }

--- a/src/main/java/pathMinder/BeltPouch.java
+++ b/src/main/java/pathMinder/BeltPouch.java
@@ -1,5 +1,5 @@
 package pathMinder;
 
 public class BeltPouch extends Container {
-	public BeltPouch() {super(null, "Pouch, belt", (float)0.5, 4, 1);}
+	public BeltPouch() {super(null, "Pouch, belt", 0.5f, 4.0f, 100);}
 }

--- a/src/main/java/pathMinder/Character.java
+++ b/src/main/java/pathMinder/Character.java
@@ -9,6 +9,7 @@ public class Character {
 	private String name;
 
 	private int baseStrength;
+	@SuppressWarnings("unused")
 	private int baseSpeed;
 
 	private Inventory inventory;

--- a/src/main/java/pathMinder/Container.java
+++ b/src/main/java/pathMinder/Container.java
@@ -99,7 +99,12 @@ public class Container extends Item implements  Set<Item> {
 	 * @see Set
 	 */
 	@Override
-	public boolean add(Item newItem) throws TooManyItemsException, IllegalArgumentException{
+	public boolean add(Item newItem) throws TooManyItemsException, IllegalArgumentException {
+		if(newItem == null) throw new NullPointerException(); //null item
+
+		if(newItem.isContained())
+			return false;
+
 		//failure case
 		if(this.contains(newItem)) return false;
 
@@ -108,6 +113,7 @@ public class Container extends Item implements  Set<Item> {
 			throw new TooManyItemsException("Unable to add item to container.");
 
 		//success case
+		newItem.setContained(true);
 		wasModified();
 		contents.add(newItem);
 		return true;
@@ -165,6 +171,7 @@ public class Container extends Item implements  Set<Item> {
 		if(!(o instanceof Item)) return false; //Containers only hold Items
 
 		if(contents.remove(o)) { //base case
+			((Item) o).setContained(false);
 			wasModified();
 			return true;
 		}

--- a/src/main/java/pathMinder/Container.java
+++ b/src/main/java/pathMinder/Container.java
@@ -18,16 +18,17 @@ import java.util.*;
  * <p>
  * TODO: add maxVolume and maxCount;
  */
-public class Container extends Item implements  Set<Item>{
+public class Container extends Item implements  Set<Item> {
 
 	public static float getWeight(Collection<? extends Item> items) {
-		float weight = (float) 0.0;
+		float weight = 0.0f;
 		for(Item item : items) { weight += item.getWeight(); }
 		return weight;
 	}
+	
 	public static float getWeight(Container items) { return items.getWeight(); }
 
-	private final LinkedHashSet<Item> contents;
+	private final HashSet<Item> contents;
 	private final float maxWeight; //the maximum weight a container can hold
 
 	/**
@@ -37,7 +38,7 @@ public class Container extends Item implements  Set<Item>{
 	private int modCount = 0;
 
 
-	protected Container(Collection<Item> contents, String name, float weight, float maxWeight, float cost) throws TooManyItemsException {
+	protected Container(Collection<Item> contents, String name, float weight, float maxWeight, int cost) throws TooManyItemsException {
 		super(name, weight, cost);
 		if(contents != null && Container.getWeight(contents) > maxWeight) throw new TooManyItemsException("Contents exceed container's maximum weight");
 		this.maxWeight = maxWeight+weight;

--- a/src/main/java/pathMinder/Container.java
+++ b/src/main/java/pathMinder/Container.java
@@ -102,6 +102,7 @@ public class Container extends Item implements  Set<Item> {
 	public boolean add(Item newItem) throws TooManyItemsException, IllegalArgumentException {
 		if(newItem == null) throw new NullPointerException(); //null item
 
+		//Item is already in a container
 		if(newItem.isContained())
 			return false;
 
@@ -192,6 +193,37 @@ public class Container extends Item implements  Set<Item> {
 	 */
 	@Override
 	public boolean removeAll(Collection items) { throw new UnsupportedOperationException(); }
+
+	/**
+	 * Instead of removing from the current container and adding to the new container,
+	 * this function does the necessary checks before hand and then modifies data directly
+	 * to improve performace.
+	 * 
+	 * @param item the item to be moved
+	 * @param newContainer the new container to move the item to
+	 * @return true if the item was successfully moved
+	 */
+	public boolean move(Item item, Container newContainer)
+	{
+		if(item == null) throw new NullPointerException(); //null item
+		if(!contains(item)) return false; //Item not located in this container
+		if(!newContainer.fits(item)) return false; //Item will not fit in the new container
+
+		//If the requested is contained within a contained item
+		if(!contents.remove(item)) {
+			for(Item i : contents) {
+				if(i instanceof Container && ((Container) i).contains(i)) { //If the item contains the requested item
+					((Container) i).contents.remove(item); 					//Remove it from its contents, and stop checking further items
+					break;
+				}
+			}
+		}
+
+		newContainer.contents.add(item);
+		wasModified();
+		newContainer.wasModified();
+		return true;
+	}
 
 	@Override
 	public boolean containsAll(Collection<?> items) {

--- a/src/main/java/pathMinder/Encumbrance.java
+++ b/src/main/java/pathMinder/Encumbrance.java
@@ -17,7 +17,7 @@ public enum Encumbrance {
 	Medium("Medium", +3, -3, 4) {
 		@Override
 		public int getSpeed(int baseSpeed) {
-			return (int) (5*Math.ceil(2*(float)baseSpeed/15));
+			return (int) (5*Math.ceil(2 * baseSpeed / 15.0f));
 		}
 		@Override
 		public int getCapacity(int strength) {

--- a/src/main/java/pathMinder/GoldCoin.java
+++ b/src/main/java/pathMinder/GoldCoin.java
@@ -1,7 +1,5 @@
 package pathMinder;
 
 public class GoldCoin extends Item {
-	public GoldCoin() {
-		super("Coin, gold", (float) 0.02, 1);
-	}
+	public GoldCoin() { super("Coin, gold", 0.02f, 100); }
 }

--- a/src/main/java/pathMinder/Inventory.java
+++ b/src/main/java/pathMinder/Inventory.java
@@ -13,7 +13,7 @@ import java.util.Set;
  * @see Character
  * @see Encumbrance
  */
-class Inventory extends ItemGroup{
+class Inventory extends ItemGroup {
 
 	private final Character holder;
 

--- a/src/main/java/pathMinder/Item.java
+++ b/src/main/java/pathMinder/Item.java
@@ -35,10 +35,10 @@ public abstract class Item {
 	 */
 	private final String name;
 	/**
-	 * The true base value of this item, measured in gold pieces. This number may be affected by other factors,
+	 * The true base value of this item, measured in copper pieces. This number may be affected by other factors,
 	 * such as being broken or masterwork.
 	 */
-	private final float cost;
+	private final int cost;
 	/**
 	 * The weight of this item, measured in pounds.
 	 */
@@ -51,10 +51,14 @@ public abstract class Item {
 	public String description;
 	private Container container = null; //the Container this item is within
 
-	protected Item(String name, float weight, float cost) {
+	protected Item(String name, float weight, int cost) {
 		this.name = name;
 		this.weight = weight;
 		this.cost = cost;
+	}
+
+	protected Item(Item item) {
+		this(item.name, item.weight, item.cost);
 	}
 
 	/**

--- a/src/main/java/pathMinder/Item.java
+++ b/src/main/java/pathMinder/Item.java
@@ -17,18 +17,6 @@ import java.util.Collection;
  * TODO: Implement intel based parameters;
  */
 public abstract class Item {
-
-	/**
-	 * Removes all the items in toRemove from their containers.
-	 * @param toRemove the collection of Items to be removed
-	 * @return true if all items were successfully removed
-	 */
-	public static boolean removeItems(Collection<? extends Item> toRemove) {
-		boolean flag = true;
-		for(Item item : toRemove.toArray(new Item[0])) if(!item.remove()) flag = false;
-		return flag;
-	}
-
 	/**
 	 * The name that identifies similar instances of an item. This does not uniquely identify this item,
 	 * to do that, the player may give their item a nickname.
@@ -79,30 +67,4 @@ public abstract class Item {
 	 * @return the name of the item
 	 */
 	public String getName() { return name; }
-
-	public boolean remove() { return container.remove(this); }
-
-	Container getContainer() { return container; }
-
-	/**
-	 * Called by a container that this item has been added to
-	 * in order to maintain the doubly linked tree structure of inventories.
-	 * If newContainer==null, then this item effectively becomes the root of a new inventory tree.
-	 * <p>
-	 * @param newContainer the container this is being added to
-	 * @return true if this Item's container was changed to newContainer
-	 * @see Container
-	 */
-	boolean setContainer(Container newContainer) {
-		if(newContainer == null && !container.contains(this)) { //parented to null
-			container = null;
-			return true;
-		}
-		if(!newContainer.contains(this)) return false; //do not put 'this' in items that do not contain it
-
-		if(container != null) this.container.remove(this); //remove 'this' from it's previous container
-		this.container = newContainer; //add 'this' to it's new container
-
-		return true;
-	}
 }

--- a/src/main/java/pathMinder/Item.java
+++ b/src/main/java/pathMinder/Item.java
@@ -37,12 +37,13 @@ public abstract class Item {
 	 */
 	public String nickName;
 	public String description;
-	private Container container = null; //the Container this item is within
+	private boolean contained;
 
 	protected Item(String name, float weight, int cost) {
 		this.name = name;
 		this.weight = weight;
 		this.cost = cost;
+		this.contained = false;
 	}
 
 	protected Item(Item item) {
@@ -67,4 +68,11 @@ public abstract class Item {
 	 * @return the name of the item
 	 */
 	public String getName() { return name; }
+
+	public void setContained(boolean contained) { this.contained = contained; }
+
+	/**
+	 * @return if the item is contained within a container
+	 */
+	public boolean isContained() { return contained; }
 }

--- a/src/main/java/pathMinder/TooManyItemsException.java
+++ b/src/main/java/pathMinder/TooManyItemsException.java
@@ -4,6 +4,12 @@ package pathMinder;
  *
  */
 public class TooManyItemsException extends RuntimeException {
+	/**
+	 * TODO: Add a unique serial id
+	 */
+
+	private static final long serialVersionUID = 1L;
+	
 	public TooManyItemsException(String message) { super(message); }
 	public TooManyItemsException(String message, Throwable err) { super(message, err); }
 }

--- a/src/test/java/pathMinder/CharacterTest.java
+++ b/src/test/java/pathMinder/CharacterTest.java
@@ -9,7 +9,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class CharacterTest {
 
 	@Test
-	public void encumbrance() {
+	public void testEncumbrance() {
 		Character character = new Character("Steve", 12, 30);
 		Encumbrance encumbrance = character.getEncumbrance();
 
@@ -27,7 +27,7 @@ public class CharacterTest {
 	}
 
 	@Test
-	public void inventory() {
+	public void testInventory() {
 		Character character = new Character("Steve", 12, 30);
 		ArrayList<Item> items = new ArrayList<>(10);
 

--- a/src/test/java/pathMinder/ContainerTest.java
+++ b/src/test/java/pathMinder/ContainerTest.java
@@ -38,6 +38,10 @@ public class ContainerTest {
 		//assertNull(ball.getContainer(), "removed ball should no longer have a parent"); ----Removal of items referencing their containers nullifies this test.----
 		assertEquals(0, innerBox.size(), "innerBox should be empty");
 		assertTrue(innerBox2.add(ball), "Ball should not be in another container.");
+		
+		assertTrue(innerBox2.move(ball, innerBox), "Ball should be moved to new container.");
+		assertTrue(innerBox.contains(ball), "innerBox should contain ball.");
+		assertFalse(innerBox2.contains(ball), "innerBox2 should no longer contain ball.");
 	}
 
 	@Test

--- a/src/test/java/pathMinder/ContainerTest.java
+++ b/src/test/java/pathMinder/ContainerTest.java
@@ -12,7 +12,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class ContainerTest {
 
 	@Test
-	public void add() {
+	public void testAdd() {
 		Box box = new Box();
 		for(int i = 0; i < 10; i++) {
 			assertTrue(box.add(new Ball()), "box was already full");
@@ -22,7 +22,7 @@ public class ContainerTest {
 	}
 
 	@Test
-	public void remove() {
+	public void testRemove() {
 		Box box = new Box();
 		Box innerBox = new Box();
 		Ball ball = new Ball();
@@ -38,7 +38,7 @@ public class ContainerTest {
 	}
 
 	@Test
-	public void getWeight() {
+	public void testGetWeight() {
 		//test empty weight
 		for(int i = 0; i < 100; i += 25) {
 			assertEquals(i, new Container(null, "TestContainer", i, 10, 1).getWeight());
@@ -76,7 +76,7 @@ public class ContainerTest {
 	}
 
 	@Test
-	public void size()  {
+	public void testSize()  {
 		//test empty container
 		assertEquals(0, new Box().size(), "empty box should have size of zero");
 
@@ -109,7 +109,7 @@ public class ContainerTest {
 	}
 
 	@Test
-	public void fits() {
+	public void testFits() {
 		//TooManyItems
 		{
 			Box box = new Box();
@@ -139,7 +139,7 @@ public class ContainerTest {
 	}
 
 	@Test
-	public void contains() {
+	public void testContains() {
 
 		//self containing
 		{
@@ -195,7 +195,7 @@ public class ContainerTest {
 	}
 
 	@Test
-	public void containsAll() {
+	public void testContainsAll() {
 
 		//throws on a null collection
 		assertThrows(NullPointerException.class, ()-> new Box().containsAll(null));
@@ -241,7 +241,7 @@ public class ContainerTest {
 	}
 
 	@Test
-	public void iterator() {
+	public void testIterator() {
 		Container box = new Box();
 		LinkedHashSet<Item> innerItems= new LinkedHashSet<>();
 

--- a/src/test/java/pathMinder/ContainerTest.java
+++ b/src/test/java/pathMinder/ContainerTest.java
@@ -273,6 +273,23 @@ public class ContainerTest {
 		for(int i = 0; i < 5; i++) iterator.next();
 		box.remove(iterator.next());
 		assertThrows(ConcurrentModificationException.class, iterator::next);
+		
+		//nested concurrent modifications
+		Box outer = new Box();
+		Box inner = new Box();
+		inner.add(new Ball());
+		inner.add(new Ball());
+		outer.add(inner);
+		
+		//Modifying inner should throw an error for outer's iterator
+		Iterator<Item> outerIterator = outer.iterator();
+		inner.add(new Ball());
+		assertThrows(ConcurrentModificationException.class, outerIterator::next);
+		
+		//Modifying outer should not throw an error for inner's iterator
+		Iterator<Item> innerIterator = inner.iterator();
+		outer.add(new Ball());
+		innerIterator.next();
 	}
 
 	private static class Box extends Container {

--- a/src/test/java/pathMinder/ContainerTest.java
+++ b/src/test/java/pathMinder/ContainerTest.java
@@ -33,7 +33,7 @@ public class ContainerTest {
 		assertThrows(NullPointerException.class, ()->box.remove(null), "remove(Item) should not accept null arguments");
 		assertTrue(box.remove(ball), "ball should've been removed");
 		assertTrue(box.remove(innerBox), "innerBox should've been removed");
-		assertNull(ball.getContainer(), "removed ball should no longer have a parent");
+		//assertNull(ball.getContainer(), "removed ball should no longer have a parent"); ----Removal of items referencing their containers nullifies this test.----
 		assertEquals(0, innerBox.size(), "innerBox should be empty");
 	}
 

--- a/src/test/java/pathMinder/ContainerTest.java
+++ b/src/test/java/pathMinder/ContainerTest.java
@@ -27,6 +27,8 @@ public class ContainerTest {
 		Box innerBox = new Box();
 		Ball ball = new Ball();
 		innerBox.add(ball);
+		Box innerBox2 = new Box();
+		assertFalse(innerBox2.add(ball), "Ball is in another container.");
 
 		assertFalse(box.remove(ball), "ball was not yet within box");
 		box.add(innerBox);
@@ -35,6 +37,7 @@ public class ContainerTest {
 		assertTrue(box.remove(innerBox), "innerBox should've been removed");
 		//assertNull(ball.getContainer(), "removed ball should no longer have a parent"); ----Removal of items referencing their containers nullifies this test.----
 		assertEquals(0, innerBox.size(), "innerBox should be empty");
+		assertTrue(innerBox2.add(ball), "Ball should not be in another container.");
 	}
 
 	@Test


### PR DESCRIPTION
Items will no longer hold a reference to the container that contains them, and instead only knows if it is contained within a container. Containers are still fail-fast, however children no longer know how many modifications a parent container has received. This is to prevent an iterator from bailing if its parent is modified, but still fail if a child is modified.

Containers also have a move function, that bypasses the overhead with removing and adding the item to two different containers.

Cost is now an integer with respect to copper, so that floating point errors won't arise when adding costs together.

Finally, modified unit test function names to have the prefix "test" in order to have Maven run them as tests, and added tests to test moving and nested containers for iteration, and removed the getContainer test.